### PR TITLE
Add serialization for parameter arrays

### DIFF
--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.Tests/Unit/Json/GraphQlParameterJsonConverterTest.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.Tests/Unit/Json/GraphQlParameterJsonConverterTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Numerics;
+using System.Text.Json;
 using Moq;
 using NUnit.Framework;
 
@@ -37,6 +38,35 @@ public class GraphQlParameterJsonConverterTest
         Dictionary<string, object?> parameters = new()
         {
             { "key", "value" },
+        };
+
+        // Arrange - Stubbing
+        MockParameter.Setup(mock => mock.Parameters)
+                     .Returns(parameters)
+                     .Verifiable($"Verify call to {nameof(MockParameter.Object.Parameters)} on ${nameof(MockParameter)}");
+
+        // Act
+        string actual = JsonSerializer.Serialize(MockParameter.Object, Options);
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expected));
+
+        // Verify
+        MockParameter.Verify();
+    }
+    
+    [Test]
+    public void SerializeGivenListGraphQlParameterReturnsExpectedJson()
+    {
+        // Arrange - Data
+        const string expected = @"{""key"":[{""param1"":1},{""param2"":true}]}";
+        var parameter1 = new TestGraphQlParameter();
+        parameter1.Set("param1", new BigInteger(1));
+        var parameter2 = new TestGraphQlParameter();
+        parameter2.Set("param2", true);
+        Dictionary<string, object?> parameters = new()
+        {
+            { "key", new List<IGraphQlParameter> {parameter1, parameter2} },
         };
 
         // Arrange - Stubbing

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.Tests/Unit/TestGraphQlParameter.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.Tests/Unit/TestGraphQlParameter.cs
@@ -1,0 +1,9 @@
+namespace Enjin.Platform.Sdk.Tests;
+
+public sealed class TestGraphQlParameter : GraphQlParameter<TestGraphQlParameter>
+{
+    public TestGraphQlParameter Set<T>(string name, T? amount)
+    {
+        return SetParameter(name, amount);
+    }
+}


### PR DESCRIPTION
- It doesn't suit for nested arrays
- Some of the object types can be serialized improperly, need to add a separate logic to serialize them (see serialization of BigInteger type).