### PR TITLE
Get signingPayloadJson working

### DIFF
--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.Tests/Unit/GraphQl/GraphQlFragmentTest.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.Tests/Unit/GraphQl/GraphQlFragmentTest.cs
@@ -23,17 +23,6 @@ public class GraphQlFragmentTest
     }
 
     [Test]
-    public void CompileFieldsWhenNoFieldsAreSetThrowsInvalidOperationException()
-    {
-        // Assumptions
-        Assume.That(ClassUnderTest.HasFields, Is.False,
-                    $"Assume {nameof(ClassUnderTest.HasFields)} is false");
-
-        // Assert
-        Assert.Throws<InvalidOperationException>(() => ClassUnderTest.CompileFields());
-    }
-
-    [Test]
     public void CompileFieldsWhenScalarFieldIsSetReturnsExpectedString()
     {
         // Arrange
@@ -104,24 +93,6 @@ public class GraphQlFragmentTest
 
         // Verify
         MockInnerFragment.Verify(mock => mock.Compile(), Times.Once);
-    }
-
-    [Test]
-    public void CompileWhenParametersAreSetAndNoFieldsAreSetThrowsInvalidOperationException()
-    {
-        // Arrange
-        const string key = "key";
-        const string value = "value";
-        ClassUnderTest.SetParameter(key, value);
-
-        // Assumptions
-        Assume.That(ClassUnderTest.HasParameters, Is.True,
-                    $"Assume {nameof(ClassUnderTest.HasParameters)} is true");
-        Assume.That(ClassUnderTest.HasFields, Is.False,
-                    $"Assume {nameof(ClassUnderTest.HasFields)} is false");
-
-        // Assert
-        Assert.Throws<InvalidOperationException>(() => ClassUnderTest.Compile());
     }
 
     [Test]

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/GraphQl/GraphQlFragment.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/GraphQl/GraphQlFragment.cs
@@ -36,7 +36,14 @@ public abstract class GraphQlFragment<TFragment> : GraphQlParameterHolder<TFragm
             builder.Append("(").Append(CompileParameters()).Append(") ");
         }
 
-        return builder.Append("{ ").Append(CompileFields()).Append(" }").ToString();
+        if (HasFields)
+        {
+            return builder.Append("{ ").Append(CompileFields()).Append(" }").ToString();
+        }
+        else
+        {
+            return builder.ToString();
+        }
     }
 
     #endregion IGraphQlCompilable
@@ -49,11 +56,6 @@ public abstract class GraphQlFragment<TFragment> : GraphQlParameterHolder<TFragm
     /// <inheritdoc/>
     public virtual string CompileFields()
     {
-        if (!HasFields)
-        {
-            throw new InvalidOperationException("Cannot compile fragment without setting any fields");
-        }
-
         int i = 0;
         int count = _scalarFields.Count + _fragmentFields.Count;
         StringBuilder builder = new StringBuilder();

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/Transaction.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/Transaction.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 using JetBrains.Annotations;
 
 namespace Enjin.Platform.Sdk;
@@ -78,4 +79,18 @@ public class Transaction
     [JsonInclude]
     [JsonPropertyName("events")]
     public Connection<Event>? Events { get; private set; }
+
+    /// <summary>
+    /// The encoded signing payload for this transaction.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("signingPayload")]
+    public string? SigningPayload { get; private set; }
+
+    /// <summary>
+    /// The decoded signing payload in json format. This is in the correct format to send to wallet connect.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("signingPayloadJson")]
+    public JsonElement? SigningPayloadJson { get; private set; }
 }

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Schema/CoreSchema.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Schema/CoreSchema.cs
@@ -403,6 +403,18 @@ public static class CoreSchema
     }
 
     /// <summary>
+    /// Sends a <see cref="SendTransaction"/> request to the platform.
+    /// </summary>
+    /// <param name="client">The <see cref="IPlatformClient"/> to send the request from.</param>
+    /// <param name="request">The <see cref="SendTransaction"/> request to send.</param>
+    /// <returns>The task containing the response.</returns>
+    public static Task<IPlatformResponse<GraphQlResponse<string>>> SendSendTransaction(
+        this IPlatformClient client, SendTransaction request)
+    {
+        return client.SendRequest<GraphQlResponse<string>>(CreateRequest(request));
+    }
+
+    /// <summary>
     /// Sends a <see cref="SetCollectionAttribute"/> request to the platform.
     /// </summary>
     /// <param name="client">The <see cref="IPlatformClient"/> to send the request from.</param>

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Schema/Mutations/SendTransaction.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Schema/Mutations/SendTransaction.cs
@@ -1,0 +1,51 @@
+﻿using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk;
+
+/// <summary>
+/// Update a transaction with a new state, transaction ID and transaction hash. Please note that the transaction ID and transaction hash are immutable once set.
+/// </summary>
+/// <remarks>
+/// 
+/// </remarks>
+[PublicAPI]
+public class SendTransaction : GraphQlRequest<SendTransaction>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SendTransaction"/> class.
+    /// </summary>
+    public SendTransaction() : base("SendTransaction", GraphQlRequestType.Mutation)
+    {
+    }
+
+    /// <summary>
+    /// Sets the internal ID of the transaction.
+    /// </summary>
+    /// <param name="id">The internal ID.</param>
+    /// <returns>This request for chaining.</returns>
+    public SendTransaction SetId(int? id)
+    {
+        return SetVariable("id", CoreTypes.Int, id);
+    }
+
+    /// <summary>
+    /// The signature for the payload.
+    /// </summary>
+    /// <param name="signature">The signature for the payload.</param>
+    /// <returns>This request for chaining.</returns>
+    public SendTransaction SetSignature(string? signature)
+    {
+        return SetVariable("signature", CoreTypes.String, signature);
+    }
+
+    /// <summary>
+    /// The payload that has been signed.
+    /// </summary>
+    /// <param name="signingPayloadJson">The transaction ID.</param>
+    /// <returns>This request for chaining.</returns>
+    public SendTransaction SetSigningPayloadJson(object? signingPayloadJson)
+    {
+        return SetVariable("signingPayloadJson", "Object!", signingPayloadJson);
+    }
+
+}


### PR DESCRIPTION
Update the SDK to handle the new signingPayload and signingPayloadJson parameters. Note that these fragments have not fields but do need parameters. This was previously unsupported. So, I had to remove the exception check and update the compile code to check for this case and do the correct thing.