### PR TITLE
Added SetupFromRequestObject helper

### DIFF
--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.FuelTanks/Model/DispatchInputType.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.FuelTanks/Model/DispatchInputType.cs
@@ -61,6 +61,14 @@ public class DispatchInputType : GraphQlParameter<DispatchInputType>
         where TFragment : IGraphQlFragment
 
     {
+        if (request.FragmentParameters != null && request.FragmentParameters is TransactionFragment transactionFragment)
+        {
+            // Ensure that Id and EncodedData are included, because they're a requirement of the DispatchInput call
+            transactionFragment
+                .WithId()
+                .WithEncodedData();
+        }
+
         var options = new JsonSerializerOptions
         {
             Converters = { new BigIntegerConverter() }

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/GraphQl/GraphQlRequest.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/GraphQl/GraphQlRequest.cs
@@ -58,6 +58,11 @@ public abstract class GraphQlRequest<TRequest, TFragment> : GraphQlRequestBase<T
     /// </summary>
     private bool HasRequestParameters => base.HasParameters;
 
+    /// <summary>
+    /// Gets the currently assigned fragment parameters
+    /// </summary>
+    public TFragment? FragmentParameters => _fragment;
+
     /// <inheritdoc/>
     protected GraphQlRequest(string name, GraphQlRequestType type) : base(name, type)
     {


### PR DESCRIPTION
This helps when interacting with a fuel tank.

I.e. if you are using a MintToken request:

```
var reqMint = new MintToken()
    .SetRecipient(walletAddress)
```

You can now just pass this in and have it auto translated for use:
```
var reqDispatch = new DispatchAndTouch()
    .SetTankId("ABC")
    .SetRuleSetId(1)
    .SetDispatch(new DispatchInputType()
        // Pass the request object in and have it auto setup
        .SetupFromRequestObject(reqMint, DispatchCall.MultiTokens)
    );
```

Additionally, the SetupFromRequestObject call also checks if it's a TransactionFragment and calls WithId and WithEncodedData, both of which are required by the Dispatch call