### PR TITLE
Added an accessor to PendingEvent to be able to get back typed data

### DIFF
--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvent.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvent.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Enjin.Platform.Sdk.PendingEvents;
 using JetBrains.Annotations;
 
 namespace Enjin.Platform.Sdk;
@@ -57,4 +58,54 @@ public class PendingEvent
     [JsonInclude]
     [JsonPropertyName("data")]
     public JsonElement? Data { get; private set; }
+    
+    public PendingEventDataBase? DataTyped
+    {
+        get
+        {
+            if (Name == null || Data == null)
+            {
+                return null;
+            }
+
+            switch (Name)
+            {
+                case "platform:transfer":
+                {
+                    return JsonSerializer.Deserialize<PendingEventDataTransfer>(Data.Value.GetRawText());
+                }
+                case "platform:token-transferred":
+                {
+                    return JsonSerializer.Deserialize<PendingEventDataTokenTransferred>(Data.Value.GetRawText());
+                }
+                case "platform:reserved":
+                {
+                    return JsonSerializer.Deserialize<PendingEventDataReserved>(Data.Value.GetRawText());
+                }
+                case "platform:withdraw":
+                {
+                    return JsonSerializer.Deserialize<PendingEventDataWithdraw>(Data.Value.GetRawText());
+                }
+                case "platform:deposit":
+                {
+                    return JsonSerializer.Deserialize<PendingEventDataDeposit>(Data.Value.GetRawText());
+                }
+                case "platform:token-minted":
+                {
+                    return JsonSerializer.Deserialize<PendingEventDataTokenMinted>(Data.Value.GetRawText());
+                }
+                case "platform:token-created":
+                {
+                    return JsonSerializer.Deserialize<PendingEventDataTokenCreated>(Data.Value.GetRawText());
+                }
+                case "platform:collection-created":
+                {
+                    return JsonSerializer.Deserialize<PendingEventDataCollectionCreated>(Data.Value.GetRawText());
+                }
+            }
+
+            // Unsupported
+            return null;
+        }
+    }
 }

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataBase.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataBase.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Enjin.Platform.Sdk.PendingEvents
+{
+    public class PendingEventDataBase
+    {
+        /// <summary>
+        /// The idempotency key set for this transaction.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("idempotencyKey")]
+        public string? IdempotencyKey { get; private set; }
+    }
+}

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataCollectionCreated.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataCollectionCreated.cs
@@ -1,0 +1,27 @@
+﻿using System.Numerics;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk.PendingEvents;
+
+/// <summary>
+/// Models event data that has been broadcasted, but not yet acknowledged.
+/// </summary>
+[PublicAPI]
+public class PendingEventDataCollectionCreated : PendingEventDataBase
+{
+    /// <summary>
+    /// The address this was sent to.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("owner")]
+    public string Owner { get; private set; }
+    
+    /// <summary>
+    /// The collection ID of this asset.
+    /// </summary>
+    [JsonConverter(typeof(NullableBigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("collectionId")]
+    public BigInteger? CollectionId { get; private set; }
+}

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataDeposit.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataDeposit.cs
@@ -1,0 +1,27 @@
+﻿using System.Numerics;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk.PendingEvents;
+
+/// <summary>
+/// Models event data that has been broadcasted, but not yet acknowledged.
+/// </summary>
+[PublicAPI]
+public class PendingEventDataDeposit : PendingEventDataBase
+{
+    /// <summary>
+    /// The address this was sent to.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("who")]
+    public string Who { get; private set; }
+
+    /// <summary>
+    /// The amount that was deposited.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("amount")]
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    public BigInteger Amount { get; private set; }
+}

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataReserved.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataReserved.cs
@@ -1,0 +1,27 @@
+﻿using System.Numerics;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk.PendingEvents;
+
+/// <summary>
+/// Models event data that has been broadcasted, but not yet acknowledged.
+/// </summary>
+[PublicAPI]
+public class PendingEventDataReserved : PendingEventDataBase
+{
+    /// <summary>
+    /// The address this was sent to.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("who")]
+    public string Who { get; private set; }
+
+    /// <summary>
+    /// The amount that was reserved.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("amount")]
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    public BigInteger Amount { get; private set; }
+}

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataTokenCreated.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataTokenCreated.cs
@@ -1,0 +1,35 @@
+﻿using System.Numerics;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk.PendingEvents;
+
+/// <summary>
+/// Models event data that has been broadcasted, but not yet acknowledged.
+/// </summary>
+[PublicAPI]
+public class PendingEventDataTokenCreated : PendingEventDataBase
+{
+    /// <summary>
+    /// The wallet that created this token.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("wallet")]
+    public string Wallet { get; private set; }
+
+    /// <summary>
+    /// The token ID of this asset.
+    /// </summary>
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("tokenId")]
+    public BigInteger TokenId { get; private set; }
+    
+    /// <summary>
+    /// The collection ID of this asset.
+    /// </summary>
+    [JsonConverter(typeof(NullableBigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("collectionId")]
+    public BigInteger? CollectionId { get; private set; }
+}

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataTokenMinted.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataTokenMinted.cs
@@ -1,0 +1,50 @@
+﻿using System.Numerics;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk.PendingEvents;
+
+/// <summary>
+/// Models event data that has been broadcasted, but not yet acknowledged.
+/// </summary>
+[PublicAPI]
+public class PendingEventDataTokenMinted : PendingEventDataBase
+{
+    /// <summary>
+    /// The amount that issued the mint.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("issuer")]
+    public string Issuer { get; private set; }
+
+    /// <summary>
+    /// The token ID of this asset.
+    /// </summary>
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("tokenId")]
+    public BigInteger TokenId { get; private set; }
+    
+    /// <summary>
+    /// The collection ID of this asset.
+    /// </summary>
+    [JsonConverter(typeof(NullableBigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("collectionId")]
+    public BigInteger? CollectionId { get; private set; }
+
+    /// <summary>
+    /// The recipient of the mint.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("recipient")]
+    public string Recipient { get; private set; }
+
+    /// <summary>
+    /// The amount that was minted.
+    /// </summary>
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("amount")]
+    public BigInteger Amount { get; private set; }
+}

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataTokenTransferred.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataTokenTransferred.cs
@@ -1,0 +1,50 @@
+﻿using System.Numerics;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk.PendingEvents;
+
+/// <summary>
+/// Models event data that has been broadcasted, but not yet acknowledged.
+/// </summary>
+[PublicAPI]
+public class PendingEventDataTokenTransferred : PendingEventDataBase
+{
+    /// <summary>
+    /// The account that this token was transferred from.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("from")]
+    public string From { get; private set; }
+
+    /// <summary>
+    /// The amount that was transferred.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("amount")]
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    public BigInteger Amount { get; private set; }
+    
+    /// <summary>
+    /// The token ID of this asset.
+    /// </summary>
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("tokenId")]
+    public BigInteger TokenId { get; private set; }
+
+    /// <summary>
+    /// The recipient of this token transfer.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("recipient")]
+    public string Recipient { get; private set; }
+
+    /// <summary>
+    /// The collection ID of this asset.
+    /// </summary>
+    [JsonConverter(typeof(NullableBigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("collectionId")]
+    public BigInteger? CollectionId { get; private set; }
+}

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataTransfer.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataTransfer.cs
@@ -1,0 +1,41 @@
+﻿using System.Numerics;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk.PendingEvents;
+
+/// <summary>
+/// Models event data that has been broadcasted, but not yet acknowledged.
+/// </summary>
+[PublicAPI]
+public class PendingEventDataTransfer : PendingEventDataBase
+{
+    /// <summary>
+    /// The address this was sent to.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("to")]
+    public string To { get; private set; }
+
+    /// <summary>
+    /// The address this was sent from.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("from")]
+    public string From { get; private set; }
+
+    /// <summary>
+    /// The amount that was transferred.
+    /// </summary>
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    [JsonInclude]
+    [JsonPropertyName("amount")]
+    public BigInteger Amount { get; private set; }
+
+    /// <summary>
+    /// The transaction hash of the transfer.
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("transactionHash")]
+    public string TransactionHash { get; private set; }
+}

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataWithdraw.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Model/PendingEvents/PendingEventDataWithdraw.cs
@@ -1,0 +1,27 @@
+﻿using System.Numerics;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace Enjin.Platform.Sdk.PendingEvents;
+
+/// <summary>
+/// Models event data that has been broadcasted, but not yet acknowledged.
+/// </summary>
+[PublicAPI]
+public class PendingEventDataWithdraw : PendingEventDataBase
+{
+    /// <summary>
+    /// The account that withdrew
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("who")]
+    public string Who { get; private set; }
+
+    /// <summary>
+    /// The amount that was withdrawn
+    /// </summary>
+    [JsonInclude]
+    [JsonPropertyName("amount")]
+    [JsonConverter(typeof(BigIntegerJsonConverter))]
+    public BigInteger Amount { get; private set; }
+}


### PR DESCRIPTION
Added an accessor to PendingEvent to be able to get back typed data, instead of just a JsonElement.

It's not fully populated and someone with some more knowledge about the events and their data would be able to better fill it out, but I think it's a great start and can easily be expanded upon.

I.e.

Now you can do the following:
```
foreach (var edge in response.Result.Data.Result.Edges)
{
    if (edge.Node.DataTyped is PendingEventDataTransfer eventDataTransfer)
    {
        Console.WriteLine($"From: {eventDataTransfer.From}");
        Console.WriteLine($"To: {eventDataTransfer.To}");
        Console.WriteLine($"Amount: {eventDataTransfer.Amount}");
    }
}
```

Instead of:
```
foreach (var edge in response.Result.Data.Result.Edges)
{
    var root = edge.Node.Data.Value;
    if (root.ValueKind == JsonValueKind.Object)
    {
        foreach (JsonProperty prop in root.EnumerateObject())
        {
            Console.WriteLine($"Key: {prop.Name}, Value: {prop.Value}");
        }
    }
}
```