### PR TITLE
Expose FragmentParameters to correctly build requests with DispatchInput

### DIFF
--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/GraphQl/GraphQlRequest.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/GraphQl/GraphQlRequest.cs
@@ -58,6 +58,11 @@ public abstract class GraphQlRequest<TRequest, TFragment> : GraphQlRequestBase<T
     /// </summary>
     private bool HasRequestParameters => base.HasParameters;
 
+    /// <summary>
+    /// Gets the currently assigned fragment parameters
+    /// </summary>
+    public TFragment? FragmentParameters => _fragment;
+
     /// <inheritdoc/>
     protected GraphQlRequest(string name, GraphQlRequestType type) : base(name, type)
     {


### PR DESCRIPTION
This allows you to get the FragmentParameters and add things like WithId() and WithEncodedData()

I.e. it allows the following extension method:

```
public static DispatchInputType SetupFromRequestObject<TRequest, TFragment>(this DispatchInputType dispatchInputType, GraphQlRequest<TRequest, TFragment> request, DispatchCall? call, out JsonDocument disposeDocument)
    where TRequest : GraphQlRequest<TRequest, TFragment>
    where TFragment : IGraphQlFragment

{
    if (request.FragmentParameters != null && request.FragmentParameters is TransactionFragment transactionFragment)
    {
        // Ensure that Id and EncodedData are included, because they're a requirement of the DispatchInput call
        transactionFragment
            .WithId()
            .WithEncodedData();
    }

    var options = new JsonSerializerOptions
    {
        Converters = { new BigIntegerJsonConverter() }
    };

    var jsonString = JsonSerializer.Serialize(request.VariablesWithoutTypes, options);
    disposeDocument = JsonDocument.Parse(jsonString);
    var jsonElement = disposeDocument.RootElement;
    return dispatchInputType.SetCall(call)
        .SetQuery(request.Compile())
        .SetVariables(jsonElement);
}
```

Which can be used to call DispatchAndTouch with the relevant request, such as:

```
 var reqDispatch = new DispatchAndTouch()
     .SetTankId(_settings.Value.EnjinPlatformFuelTankId)
     .SetRuleSetId(BigInteger.Parse(_settings.Value.EnjinPlatformFuelTankRuleSetId))
     .SetDispatch(new DispatchInputType()
         .SetupFromRequestObject(reqTransferBalance, DispatchCall.MultiTokens, out var disposeDocument)
     );

 reqDispatch.Fragment(new TransactionFragment().WithTransactionHash());
 var response = await _enjinPlatformService.Client.SendDispatchAndTouch(reqDispatch);
 disposeDocument.Dispose();
 ```
 
 Perhaps something like this could be integrated into the SDK in the future, if it's desirable.

(It would also be nice to remove this dependency on a JsonDocument, but I haven't got the time to work on it)