### PR TITLE
Add SetStates API for use with GetListings request

### DIFF
--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.Marketplace/Schema/Queries/GetListings.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk.Marketplace/Schema/Queries/GetListings.cs
@@ -67,4 +67,14 @@ public class GetListings : GraphQlRequest<GetListings, MarketplaceListingConnect
     {
         return SetVariable("takeAssetId", CoreTypes.MultiTokenIdInput, takeAssetId);
     }
+
+    /// <summary>
+    /// Sets the listing states that will be returned.
+    /// </summary>
+    /// <param name="states">The list of states that you want returned</param>
+    /// <returns>This request for chaining.</returns>
+    public GetListings SetStates(params ListingStateEnum[]? states)
+    {
+        return SetVariable("states", CoreTypes.ListingStateEnumArray, states);
+    }
 }

--- a/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Schema/CoreTypes.cs
+++ b/src/Enjin.Platform.Sdk/Enjin.Platform.Sdk/Schema/CoreTypes.cs
@@ -331,4 +331,16 @@ public static class CoreTypes
     /// String for an array of <c>TransferRecipient</c> type.
     /// </summary>
     public const string TransferRecipientArray = "[TransferRecipient!]!";
+
+    // ListingStateEnum
+
+    /// <summary>
+    /// String for <c>ListingStateEnum</c> type.
+    /// </summary>
+    public const string ListingStateEnum = "ListingStateEnum!";
+
+    /// <summary>
+    /// String for an array of <c>ListingStateEnumArray</c> type.
+    /// </summary>
+    public const string ListingStateEnumArray = "[ListingStateEnum!]!";
 }


### PR DESCRIPTION
The SetStates parameter was added to the GetListings request in the platform to avoid returning listings in unneeded states like cancelled or finalized. This change updates the SDK to include that new parameter as well. I have validated it is working end to end in Etherscape.